### PR TITLE
Implement optional serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,10 @@ keywords = ["trie", "patricia", "collection", "generic", "prefix"]
 
 nibble_vec = "0.0.3"
 "endian-type" = "0.1.2"
+serde = { version = "0.8", optional = true }
 
 [dev-dependencies]
 
 quickcheck = "0.2"
 rand = "0.3"
+serde_test = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ mod trie;
 mod subtrie;
 mod trie_node;
 mod trie_common;
+#[cfg(feature = "serde")]
+mod serde;
 
 #[cfg(test)]
 mod test;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,210 @@
+extern crate serde;
+
+use super::{Trie, TrieKey, TrieCommon};
+use self::serde::{Serialize, Serializer, Deserialize, Deserializer, de, Error};
+use std::marker::PhantomData;
+
+impl<K, V> Serialize for Trie<K, V>
+    where K: Serialize + TrieKey,
+          V: Serialize
+{
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+        where S: Serializer
+    {
+        let mut state = try!(serializer.serialize_map(Some(self.len())));
+        for (k, v) in self.iter() {
+            try!(serializer.serialize_map_key(&mut state, k));
+            try!(serializer.serialize_map_value(&mut state, v));
+        }
+        serializer.serialize_map_end(state)
+    }
+}
+
+
+struct TrieVisitor<K, V> {
+    marker: PhantomData<Trie<K, V>>,
+}
+
+impl<K, V> TrieVisitor<K, V> {
+    fn new() -> Self {
+        TrieVisitor { marker: PhantomData }
+    }
+}
+
+impl<K, V> de::Visitor for TrieVisitor<K, V>
+    where K: Deserialize + Clone + Eq + PartialEq + TrieKey,
+          V: Deserialize
+{
+    type Value = Trie<K, V>;
+
+    fn visit_map<M>(&mut self, mut visitor: M) -> Result<Self::Value, M::Error>
+        where M: de::MapVisitor
+    {
+        let mut values = Trie::new();
+
+        while let Some((key, value)) = try!(visitor.visit()) {
+            values.insert(key, value);
+        }
+
+        try!(visitor.end());
+        Ok(values)
+    }
+
+    fn visit_unit<E>(&mut self) -> Result<Self::Value, E>
+        where E: Error
+    {
+        Ok(Trie::new())
+    }
+}
+
+impl<K, V> Deserialize for Trie<K, V>
+    where K: Deserialize + Clone + Eq + PartialEq + TrieKey,
+          V: Deserialize
+{
+    fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
+        where D: Deserializer
+    {
+        // Instantiate our Visitor and ask the Deserializer to drive
+        // it over the input data, resulting in an instance of MyMap.
+        deserializer.deserialize_map(TrieVisitor::new())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    extern crate serde_test;
+    use self::serde_test::{Token};
+    use super::super::Trie;
+
+    macro_rules! tests_de {
+        ($($name:ident => $value:expr => $tokens:expr,)+) => {
+            $(#[test]
+            fn $name() {
+                // Test ser/de roundtripping
+                serde_test::assert_de_tokens(&$value, $tokens);
+            })+
+        }
+    }
+
+    macro_rules! tests_ser {
+        ($($name:ident => $value:expr => $tokens:expr,)+) => {
+            $(#[test]
+            fn $name() {
+                serde_test::assert_ser_tokens(&$value, $tokens);
+            })+
+        }
+    }
+
+    macro_rules! trie {
+        () => {
+            Trie::new()
+        };
+        ($($key:expr => $value:expr),+) => {
+            {
+                let mut map = Trie::new();
+                $(map.insert($key, $value);)+
+                map
+            }
+        }
+    }
+
+    tests_ser! {
+        test_ser_empty_trie => Trie::<&str, isize>::new() => &[
+            Token::MapStart(Some(0)),
+            Token::MapEnd,
+        ],
+        test_ser_single_element_trie => trie!["1" => 2] => &[
+            Token::MapStart(Some(1)),
+            Token::MapSep,
+            Token::Str("1"),
+            Token::I32(2),
+            Token::MapEnd,
+        ],
+        test_ser_multiple_element_trie => trie!["1" => 2, "3" => 4] => &[
+            Token::MapStart(Some(2)),
+            Token::MapSep,
+            Token::Str("1"),
+            Token::I32(2),
+
+            Token::MapSep,
+            Token::Str("3"),
+            Token::I32(4),
+            Token::MapEnd,
+        ],
+        test_ser_deep_trie => trie!["1" => trie![], "2" => trie!["3" => 4, "5" => 6]] => &[
+            Token::MapStart(Some(2)),
+            Token::MapSep,
+            Token::Str("1"),
+            Token::MapStart(Some(0)),
+            Token::MapEnd,
+
+            Token::MapSep,
+            Token::Str("2"),
+            Token::MapStart(Some(2)),
+            Token::MapSep,
+            Token::Str("3"),
+            Token::I32(4),
+
+            Token::MapSep,
+            Token::Str("5"),
+            Token::I32(6),
+            Token::MapEnd,
+            Token::MapEnd,
+        ],
+    }
+
+    tests_de! {
+        test_de_empty_trie1 => Trie::<String, isize>::new() => &[
+            Token::Unit,
+        ],
+        test_de_empty_trie2 => Trie::<String, isize>::new() => &[
+            Token::MapStart(Some(0)),
+            Token::MapEnd,
+        ],
+        test_de_single_element_trie => trie!["1".to_string() => 2] => &[
+            Token::MapStart(Some(1)),
+                Token::MapSep,
+                Token::Str("1"),
+                Token::I32(2),
+            Token::MapEnd,
+        ],
+        test_de_multiple_element_trie => trie!["1".to_string()  => 2, "3".to_string()  => 4] => &[
+            Token::MapStart(Some(2)),
+                Token::MapSep,
+                Token::Str("1"),
+                Token::I32(2),
+
+                Token::MapSep,
+                Token::Str("3"),
+                Token::I32(4),
+            Token::MapEnd,
+        ],
+        test_de_deep_trie => trie!["1".to_string()  => trie![], "2".to_string()  => trie!["3".to_string()  => 4, "5".to_string()  => 6]] => &[
+            Token::MapStart(Some(2)),
+                Token::MapSep,
+                Token::Str("1"),
+                Token::MapStart(Some(0)),
+                Token::MapEnd,
+
+                Token::MapSep,
+                Token::Str("2"),
+                Token::MapStart(Some(2)),
+                    Token::MapSep,
+                    Token::Str("3"),
+                    Token::I32(4),
+
+                    Token::MapSep,
+                    Token::Str("5"),
+                    Token::I32(6),
+                Token::MapEnd,
+            Token::MapEnd,
+        ],
+        test_de_empty_trie3 => Trie::<String, isize>::new() => &[
+            Token::UnitStruct("Anything"),
+        ],
+        test_de_empty_trie4 => Trie::<String, isize>::new() => &[
+            Token::StructStart("Anything", 0),
+            Token::MapEnd,
+        ],
+    }
+}

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -1,4 +1,4 @@
-use {Trie, TrieNode, TrieKey, SubTrie, SubTrieMut, NibbleVec};
+use {Trie, TrieCommon, TrieNode, TrieKey, SubTrie, SubTrieMut, NibbleVec};
 use traversal::DescendantResult::*;
 
 impl<K, V> Trie<K, V>
@@ -130,5 +130,15 @@ impl<K, V> Trie<K, V>
     pub fn check_integrity(&self) -> bool {
         let (ok, length) = self.node.check_integrity_recursive(&NibbleVec::new());
         ok && length == self.length
+    }
+}
+
+impl<K, V> PartialEq for Trie<K, V> where K: TrieKey, V: PartialEq {
+    fn eq(&self, other: &Trie<K, V>) -> bool {
+        if self.len() != other.len() { return false; }
+
+        self.iter().all(|(key, value)|
+            other.get(key).map_or(false, |v| *value == *v)
+        )
     }
 }


### PR DESCRIPTION
Implements serde serialization/deserialization (mostly a copy paste of serde's hashmap impls, modified to work on tries).

Also adds PartialEq to Trie, required to make it work with serde_test (and besides, it seems useful).