### PR TITLE
Make TrieNode private

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -3,7 +3,8 @@
 use std::slice;
 use std::iter::{Map, FilterMap, FromIterator};
 
-use {Trie, TrieNode, TrieKey, SubTrie, NibbleVec};
+use {Trie, TrieKey, SubTrie, NibbleVec};
+use trie_node::TrieNode;
 
 // MY EYES.
 type Child<K, V> = Box<TrieNode<K, V>>;
@@ -19,6 +20,7 @@ pub struct Iter<'a, K: 'a, V: 'a> {
 }
 
 impl<'a, K, V> Iter<'a, K, V> {
+    // TODO: make this private somehow (and same for the other iterators).
     pub fn new(root: &'a TrieNode<K, V>) -> Iter<'a, K, V> {
         Iter {
             root: root,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate rand;
 pub use nibble_vec::NibbleVec;
 pub use keys::TrieKey;
 pub use trie_common::TrieCommon;
+use trie_node::TrieNode;
 
 #[macro_use]
 mod macros;
@@ -51,30 +52,6 @@ pub struct Trie<K, V> {
     length: usize,
     /// The main content of this trie.
     node: TrieNode<K, V>,
-}
-
-/// Internal trie node (avoid using explicitly).
-#[derive(Debug)]
-pub struct TrieNode<K, V> {
-    /// Key fragments/bits associated with this node, such that joining the keys from all
-    /// parent nodes and this node is equal to the bit-encoding of this node's key.
-    key: NibbleVec,
-
-    /// The key and value stored at this node.
-    key_value: Option<Box<KeyValue<K, V>>>,
-
-    /// The number of children which are Some rather than None.
-    child_count: usize,
-
-    /// The children of this node stored such that the first nibble of each child key
-    /// dictates the child's bucket.
-    children: [Option<Box<TrieNode<K, V>>>; BRANCH_FACTOR],
-}
-
-#[derive(Debug)]
-struct KeyValue<K, V> {
-    key: K,
-    value: V,
 }
 
 /// Immutable view of a sub-tree a larger trie.

--- a/src/subtrie.rs
+++ b/src/subtrie.rs
@@ -1,16 +1,10 @@
-use {TrieNode, SubTrie, SubTrieMut, SubTrieResult, NibbleVec};
+use {SubTrie, SubTrieMut, SubTrieResult, NibbleVec};
+use trie_node::TrieNode;
 use keys::*;
 
 impl<'a, K, V> SubTrie<'a, K, V>
     where K: TrieKey
 {
-    pub fn new(prefix: NibbleVec, node: &'a TrieNode<K, V>) -> Self {
-        SubTrie {
-            prefix: prefix,
-            node: node,
-        }
-    }
-
     /// Look up the value for the given key, which should be an extension of this subtrie's key.
     pub fn get(&self, key: &K) -> SubTrieResult<&V> {
         subtrie_get(&self.prefix, self.node, key)
@@ -34,14 +28,6 @@ fn subtrie_get<'a, K, V>(prefix: &NibbleVec,
 impl<'a, K, V> SubTrieMut<'a, K, V>
     where K: TrieKey
 {
-    pub fn new(prefix: NibbleVec, length: &'a mut usize, node: &'a mut TrieNode<K, V>) -> Self {
-        SubTrieMut {
-            prefix: prefix,
-            length: length,
-            node: node,
-        }
-    }
-
     /// Mutable reference to the node's value.
     pub fn value_mut(&mut self) -> Option<&mut V> {
         self.node.value_mut()

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::iter::FromIterator;
 use {Trie, TrieCommon};
 
 const TEST_DATA: [(&'static str, u32); 7] = [("abcdefgh", 19),
@@ -293,4 +294,14 @@ fn int_keys() {
     trie.insert(0x00ffu64, "asdf");
     trie.insert(0xdeadbeefu64, "asdf");
     assert!(trie.check_integrity());
+}
+
+#[test]
+fn from_iter() {
+    let trie: Trie<&str, u32> = Trie::from_iter(vec![
+        ("test", 10), ("hello", 12)
+    ]);
+    assert_eq!(*trie.get(&"test").unwrap(), 10);
+    assert_eq!(*trie.get(&"hello").unwrap(), 12);
+    assert_eq!(trie.len(), 2);
 }

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -1,6 +1,7 @@
 //! This module contains the core algorithms.
 
-use {TrieNode, TrieKey, NibbleVec};
+use {TrieKey, NibbleVec};
+use trie_node::TrieNode;
 use keys::{match_keys, KeyMatch};
 
 use self::DescendantResult::*;

--- a/src/trie_common.rs
+++ b/src/trie_common.rs
@@ -1,4 +1,5 @@
-use {Trie, TrieNode, TrieKey, SubTrie, SubTrieMut};
+use {Trie, TrieKey, SubTrie, SubTrieMut};
+use trie_node::TrieNode;
 use iter::*;
 
 /// Common functionality available for tries and subtries.


### PR DESCRIPTION
I read the docs for privacy and was pleasantly surprised by the actual simplicity of the rules. The good news is, `TrieNode` can be made private without too much fuss. The iterators still need to be fixed though.