### PR TITLE
 Prevent panics when removing non-existent keys

### DIFF
--- a/src/qc_test.rs
+++ b/src/qc_test.rs
@@ -232,6 +232,21 @@ fn length_trie(keys: HashSet<Key>) -> Trie<Key, usize> {
 }
 
 #[test]
+fn remove_non_existent() {
+    fn prop(RandomKeys(insert_keys): RandomKeys, RandomKeys(remove_keys): RandomKeys) -> bool {
+        let mut trie = length_trie(insert_keys.clone());
+
+        for k in remove_keys {
+            if !insert_keys.contains(&k) && !trie.remove(&k).is_none() {
+                return false;
+            }
+        }
+        true
+    }
+    quickcheck(prop as fn(RandomKeys, RandomKeys) -> bool);
+}
+
+#[test]
 fn keys_iter() {
     fn prop(RandomKeys(keys): RandomKeys) -> bool {
         let trie = length_trie(keys.clone());

--- a/src/test.rs
+++ b/src/test.rs
@@ -140,6 +140,26 @@ fn remove_simple() {
 }
 
 #[test]
+fn remove_non_existent() {
+    let mut trie = Trie::new();
+
+    trie.insert("acab", true);
+
+    assert_eq!(trie.remove(&"abc"), None);
+    assert_eq!(trie.remove(&"acaba"), None);
+    assert_eq!(trie.remove(&"a"), None);
+    assert_eq!(trie.remove(&""), None);
+    assert_eq!(trie.len(), 1);
+
+    trie.insert("acaz", true);
+
+    assert_eq!(trie.remove(&"acb"), None);
+    assert_eq!(trie.remove(&"acaca"), None);
+    assert_eq!(trie.remove(&"aca"), None);
+    assert_eq!(trie.len(), 2);
+}
+
+#[test]
 fn nearest_ancestor_root() {
     let mut trie = Trie::new();
     trie.insert("", 55);


### PR DESCRIPTION
There was a bug whereby removing a key that had not been inserted into the trie would cause a `panic!` because its value wasn't checked in `recursive_remove` before calling `rec_remove`. The length was checked instead, but in hindsight, that's obviously insufficient.

The solution was to copy (!) more of the key-checking logic from `rec_remove` into the top-level `recursive_remove`. The logic to merge the parent with its only child is not required in the top-level, because the root node should always retain its `[]` key.

Closes #40