### PR TITLE
Minor changes

### DIFF
--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -100,7 +100,7 @@ where
 
     /// Compute the number of keys and values in this node's subtrie.
     pub fn compute_size(&self) -> usize {
-        let mut size = if self.key_value.is_some() { 1 } else { 0 };
+        let mut size = self.key_value.is_some() as usize;
 
         for child in &self.children {
             if let Some(ref child) = *child {

--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -26,15 +26,6 @@ pub struct KeyValue<K, V> {
     pub value: V,
 }
 
-macro_rules! no_children {
-    () => {
-        [
-            None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-            None, None,
-        ]
-    };
-}
-
 impl<K, V> TrieNode<K, V>
 where
     K: TrieKey,
@@ -44,7 +35,7 @@ where
         TrieNode {
             key: NibbleVec::new(),
             key_value: None,
-            children: no_children![],
+            children: Default::default(),
             child_count: 0,
         }
     }
@@ -57,7 +48,7 @@ where
                 key: key,
                 value: value,
             })),
-            children: no_children![],
+            children: Default::default(),
             child_count: 0,
         }
     }
@@ -192,7 +183,7 @@ where
         let key_value = self.key_value.take();
 
         // Children.
-        let mut children = no_children![];
+        let mut children: [Option<Box<TrieNode<K, V>>>; BRANCH_FACTOR] = Default::default();
 
         for (i, child) in self.children.iter_mut().enumerate() {
             if child.is_some() {


### PR DESCRIPTION
* 1st commit
Replaced invocations of macro `no_children!` with calls to `Default::default()`.
In this way, program code is resilient to changes of `const BRANCH_FACTOR`
(code needn't be fixed every time the value of `const BRANCH_FACTOR` is changed). 
`cargo bench` didn't show performance degradations.

* 2nd commit
make code slightly more concise 