### PR TITLE
Bump nibble_vec 0.0.3 -> 0.1.0 and update all code to use Nibblet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["trie", "patricia", "collection", "generic", "prefix"]
 categories = ["data-structures", "text-processing"]
 
 [dependencies]
-nibble_vec = "~0.0.5"
+nibble_vec = "0.1"
 endian-type = "0.1.2"
 serde = { version = "1.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["trie", "patricia", "collection", "generic", "prefix"]
 categories = ["data-structures", "text-processing"]
 
 [dependencies]
-nibble_vec = "~0.0.3"
+nibble_vec = "~0.0.5"
 endian-type = "0.1.2"
 serde = { version = "1.0", optional = true }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -4,7 +4,9 @@ use std::iter::{FilterMap, FromIterator, Map};
 use std::slice;
 
 use crate::TrieNode;
-use crate::{NibbleVec, SubTrie, Trie, TrieKey};
+use crate::{SubTrie, Trie, TrieKey};
+
+use nibble_vec::Nibblet;
 
 // MY EYES.
 type Child<K, V> = Box<TrieNode<K, V>>;
@@ -84,12 +86,12 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
 
 /// Iterator over the child subtries of a trie.
 pub struct Children<'a, K: 'a, V: 'a> {
-    prefix: NibbleVec,
+    prefix: Nibblet,
     inner: ChildIter<'a, K, V>,
 }
 
 impl<'a, K, V> Children<'a, K, V> {
-    pub fn new(key: NibbleVec, node: &'a TrieNode<K, V>) -> Self {
+    pub fn new(key: Nibblet, node: &'a TrieNode<K, V>) -> Self {
         Children {
             prefix: key,
             inner: node.child_iter(),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,14 +1,15 @@
-use crate::NibbleVec;
 use endian_type::{BigEndian, LittleEndian};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+
+use nibble_vec::Nibblet;
 
 /// Trait for types which can be used to key a Radix Trie.
 ///
 /// Types that implement this trait should be convertible to a vector of half-bytes (nibbles)
 /// such that no two instances of the type convert to the same vector.
 /// To protect against faulty behaviour, the trie will **panic** if it finds two distinct keys
-/// of type `K` which encode to the same `NibbleVec`, so be careful!
+/// of type `K` which encode to the same `Nibblet`, so be careful!
 ///
 /// If you would like to implement this trait for your own type, you need to implement
 /// *either* `encode_bytes` or `encode`. You only need to implement one of the two.
@@ -25,8 +26,9 @@ pub trait TrieKey: PartialEq + Eq {
     }
 
     /// Encode a value as a NibbleVec.
-    fn encode(&self) -> NibbleVec {
-        NibbleVec::from_byte_vec(self.encode_bytes())
+    #[inline]
+    fn encode(&self) -> Nibblet {
+        Nibblet::from_byte_vec(self.encode_bytes())
     }
 }
 
@@ -46,7 +48,8 @@ pub enum KeyMatch {
 /// Compare two Trie keys.
 ///
 /// Compares `first[start_idx .. ]` to `second`, i.e. only looks at a slice of the first key.
-pub fn match_keys(start_idx: usize, first: &NibbleVec, second: &NibbleVec) -> KeyMatch {
+#[inline]
+pub fn match_keys(start_idx: usize, first: &Nibblet, second: &Nibblet) -> KeyMatch {
     let first_len = first.len() - start_idx;
     let min_length = ::std::cmp::min(first_len, second.len());
 
@@ -64,6 +67,7 @@ pub fn match_keys(start_idx: usize, first: &NibbleVec, second: &NibbleVec) -> Ke
 }
 
 /// Check two keys for equality and panic if they differ.
+#[inline]
 pub fn check_keys<K: ?Sized>(key1: &K, key2: &K)
 where
     K: TrieKey,
@@ -83,42 +87,49 @@ where
 // }
 
 impl TrieKey for Vec<u8> {
+    #[inline]
     fn encode_bytes(&self) -> Vec<u8> {
         self.clone()
     }
 }
 
 impl TrieKey for [u8] {
+    #[inline]
     fn encode_bytes(&self) -> Vec<u8> {
         self.to_vec()
     }
 }
 
 impl TrieKey for String {
+    #[inline]
     fn encode_bytes(&self) -> Vec<u8> {
         self.as_bytes().encode_bytes()
     }
 }
 
 impl TrieKey for str {
+    #[inline]
     fn encode_bytes(&self) -> Vec<u8> {
         self.as_bytes().encode_bytes()
     }
 }
 
 impl<'a, T: ?Sized + TrieKey> TrieKey for &'a T {
+    #[inline]
     fn encode_bytes(&self) -> Vec<u8> {
         (**self).encode_bytes()
     }
 }
 
 impl<'a, T: ?Sized + TrieKey> TrieKey for &'a mut T {
+    #[inline]
     fn encode_bytes(&self) -> Vec<u8> {
         (**self).encode_bytes()
     }
 }
 
 impl TrieKey for i8 {
+    #[inline]
     fn encode_bytes(&self) -> Vec<u8> {
         let mut v: Vec<u8> = Vec::with_capacity(1);
         v.push(*self as u8);
@@ -127,6 +138,7 @@ impl TrieKey for i8 {
 }
 
 impl TrieKey for u8 {
+    #[inline]
     fn encode_bytes(&self) -> Vec<u8> {
         let mut v: Vec<u8> = Vec::with_capacity(1);
         v.push(*self);
@@ -148,6 +160,25 @@ impl TrieKey for Path {
     fn encode_bytes(&self) -> Vec<u8> {
         use std::os::unix::ffi::OsStrExt;
         self.as_os_str().as_bytes().encode_bytes()
+    }
+}
+
+#[cfg(windows)]
+impl TrieKey for PathBuf {
+    fn encode_bytes(&self) -> Vec<u8> {
+        let str: OsString = self.clone().into();
+        str.into_string()
+            .unwrap()
+            .as_str()
+            .as_bytes()
+            .encode_bytes()
+    }
+}
+
+#[cfg(windows)]
+impl TrieKey for Path {
+    fn encode_bytes(&self) -> Vec<u8> {
+        self.to_str().unwrap().as_bytes().encode_bytes()
     }
 }
 
@@ -183,3 +214,41 @@ macro_rules! int_keys {
 }
 
 int_keys!(u16, u32, u64, i16, i32, i64, usize, isize);
+
+#[cfg(test)]
+mod test {
+    pub trait DefaultTrieKey {
+        fn encode_bytes(&self) -> Vec<u8>;
+    }
+
+    impl<T: Into<Vec<u8>> + Clone + PartialEq + Eq> DefaultTrieKey for T {
+        #[inline]
+        fn encode_bytes(&self) -> Vec<u8> {
+            self.clone().into()
+        }
+    }
+
+    pub trait AsTrieKey {
+        fn encode_bytes(&self) -> Vec<u8>;
+    }
+
+    impl<T: AsRef<[u8]> + Clone + PartialEq + Eq> AsTrieKey for &T {
+        #[inline]
+        fn encode_bytes(&self) -> Vec<u8> {
+            self.as_ref().to_vec()
+        }
+    }
+
+    macro_rules! encode_bytes {
+        ($e:expr) => {
+            (&$e).encode_bytes()
+        };
+    }
+
+    #[test]
+    fn test_autoref_specialization() {
+        let _ = encode_bytes!([0_u8]);
+        let _ = encode_bytes!("hello");
+        let _ = encode_bytes!("hello".to_string());
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -163,25 +163,6 @@ impl TrieKey for Path {
     }
 }
 
-#[cfg(windows)]
-impl TrieKey for PathBuf {
-    fn encode_bytes(&self) -> Vec<u8> {
-        let str: OsString = self.clone().into();
-        str.into_string()
-            .unwrap()
-            .as_str()
-            .as_bytes()
-            .encode_bytes()
-    }
-}
-
-#[cfg(windows)]
-impl TrieKey for Path {
-    fn encode_bytes(&self) -> Vec<u8> {
-        self.to_str().unwrap().as_bytes().encode_bytes()
-    }
-}
-
 impl<T> TrieKey for LittleEndian<T>
 where
     T: Eq + Copy,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ pub use nibble_vec::NibbleVec;
 pub use trie_common::TrieCommon;
 use trie_node::TrieNode;
 
+use nibble_vec::Nibblet;
+
 #[macro_use]
 mod macros;
 pub mod iter;
@@ -57,14 +59,14 @@ pub struct Trie<K, V> {
 /// Immutable view of a sub-tree a larger trie.
 #[derive(Debug)]
 pub struct SubTrie<'a, K: 'a, V: 'a> {
-    prefix: NibbleVec,
+    prefix: Nibblet,
     node: &'a TrieNode<K, V>,
 }
 
 /// Mutable view of a sub-tree of a larger trie.
 #[derive(Debug)]
 pub struct SubTrieMut<'a, K: 'a, V: 'a> {
-    prefix: NibbleVec,
+    prefix: Nibblet,
     length: &'a mut usize,
     node: &'a mut TrieNode<K, V>,
 }

--- a/src/subtrie.rs
+++ b/src/subtrie.rs
@@ -1,7 +1,9 @@
 use crate::keys::*;
 use crate::TrieNode;
-use crate::{NibbleVec, SubTrie, SubTrieMut, SubTrieResult};
+use crate::{SubTrie, SubTrieMut, SubTrieResult};
 use std::borrow::Borrow;
+
+use nibble_vec::Nibblet;
 
 impl<'a, K, V> SubTrie<'a, K, V>
 where
@@ -21,7 +23,7 @@ where
 }
 
 fn subtrie_get<'a, K, Q: ?Sized, V>(
-    prefix: &NibbleVec,
+    prefix: &Nibblet,
     node: &'a TrieNode<K, V>,
     key: &Q,
 ) -> SubTrieResult<&'a V>
@@ -107,6 +109,6 @@ where
     }
 }
 
-fn stripped(mut key: NibbleVec, prefix: &NibbleVec) -> NibbleVec {
+fn stripped(mut key: Nibblet, prefix: &Nibblet) -> Nibblet {
     key.split(prefix.len())
 }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -1,13 +1,16 @@
 use crate::traversal::DescendantResult::*;
 use crate::TrieNode;
-use crate::{NibbleVec, SubTrie, SubTrieMut, Trie, TrieCommon, TrieKey};
+use crate::{SubTrie, SubTrieMut, Trie, TrieCommon, TrieKey};
 use std::borrow::Borrow;
+
+use nibble_vec::Nibblet;
 
 impl<K, V> Trie<K, V>
 where
     K: TrieKey,
 {
     /// Create an empty Trie.
+    #[inline]
     pub fn new() -> Trie<K, V> {
         Trie {
             length: 0,
@@ -18,7 +21,8 @@ where
     /// Fetch a reference to the given key's corresponding value, if any.
     ///
     /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
-    /// form *must* match those for the key type
+    /// form *must* match those for the key type.
+    #[inline]
     pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
@@ -33,7 +37,8 @@ where
     /// Fetch a mutable reference to the given key's corresponding value, if any.
     ///
     /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
-    /// form *must* match those for the key type
+    /// form *must* match those for the key type.
+    #[inline]
     pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
@@ -46,6 +51,7 @@ where
     }
 
     /// Insert the given key-value pair, returning any previous value associated with the key.
+    #[inline]
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         let key_fragments = key.encode();
         let result = self.node.insert(key, value, key_fragments);
@@ -58,7 +64,8 @@ where
     /// Remove the value associated with the given key.
     ///
     /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
-    /// form *must* match those for the key type
+    /// form *must* match those for the key type.
+    #[inline]
     pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
@@ -79,7 +86,8 @@ where
     /// Fetch a reference to the subtrie for a given key.
     ///
     /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
-    /// form *must* match those for the key type
+    /// form *must* match those for the key type.
+    #[inline]
     pub fn subtrie<'a, Q: ?Sized>(&'a self, key: &Q) -> Option<SubTrie<'a, K, V>>
     where
         K: Borrow<Q>,
@@ -94,7 +102,8 @@ where
     /// Fetch a mutable reference to the subtrie for a given key.
     ///
     /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
-    /// form *must* match those for the key type
+    /// form *must* match those for the key type.
+    #[inline]
     pub fn subtrie_mut<'a, Q: ?Sized>(&'a mut self, key: &Q) -> Option<SubTrieMut<'a, K, V>>
     where
         K: Borrow<Q>,
@@ -116,7 +125,8 @@ where
     /// Invariant: `result.is_some() => result.key_value.is_some()`.
     ///
     /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
-    /// form *must* match those for the key type
+    /// form *must* match those for the key type.
+    #[inline]
     pub fn get_ancestor<'a, Q: ?Sized>(&'a self, key: &Q) -> Option<SubTrie<'a, K, V>>
     where
         K: Borrow<Q>,
@@ -136,7 +146,8 @@ where
     /// See `get_ancestor` for precise semantics, this is just a shortcut.
     ///
     /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
-    /// form *must* match those for the key type
+    /// form *must* match those for the key type.
+    #[inline]
     pub fn get_ancestor_value<Q: ?Sized>(&self, key: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
@@ -147,6 +158,7 @@ where
 
     /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
     /// form *must* match those for the key type
+    #[inline]
     pub fn get_raw_ancestor<'a, Q: ?Sized>(&'a self, key: &Q) -> SubTrie<'a, K, V>
     where
         K: Borrow<Q>,
@@ -164,6 +176,7 @@ where
     ///
     /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
     /// form *must* match those for the key type
+    #[inline]
     pub fn get_raw_descendant<'a, Q: ?Sized>(&'a self, key: &Q) -> Option<SubTrie<'a, K, V>>
     where
         K: Borrow<Q>,
@@ -185,6 +198,7 @@ where
     /// Take a function `f` and apply it to the value stored at `key`.
     ///
     /// If no value is stored at `key`, store `default`.
+    #[inline]
     pub fn map_with_default<F>(&mut self, key: K, f: F, default: V)
     where
         F: Fn(&mut V),
@@ -202,7 +216,7 @@ where
     /// Quite slow!
     #[doc(hidden)]
     pub fn check_integrity(&self) -> bool {
-        let (ok, length) = self.node.check_integrity_recursive(&NibbleVec::new());
+        let (ok, length) = self.node.check_integrity_recursive(&Nibblet::new());
         ok && length == self.length
     }
 }
@@ -212,6 +226,7 @@ where
     K: TrieKey,
     V: PartialEq,
 {
+    #[inline]
     fn eq(&self, other: &Trie<K, V>) -> bool {
         if self.len() != other.len() {
             return false;
@@ -223,6 +238,7 @@ where
 }
 
 impl<K: TrieKey, V> Default for Trie<K, V> {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/src/trie_common.rs
+++ b/src/trie_common.rs
@@ -1,6 +1,8 @@
 use crate::iter::*;
 use crate::TrieNode;
-use crate::{NibbleVec, SubTrie, SubTrieMut, Trie, TrieKey};
+use crate::{SubTrie, SubTrieMut, Trie, TrieKey};
+
+use nibble_vec::Nibblet;
 
 /// Common functionality available for tries and subtries.
 pub trait TrieCommon<'a, K: 'a, V: 'a>: ContainsTrieNode<'a, K, V>
@@ -9,11 +11,13 @@ where
     Self: Sized,
 {
     /// Get the key stored at this node, if any.
+    #[inline]
     fn key(self) -> Option<&'a K> {
         self.trie_node().key()
     }
 
     /// Get the value stored at this node, if any.
+    #[inline]
     fn value(self) -> Option<&'a V> {
         self.trie_node().value()
     }
@@ -22,26 +26,31 @@ where
     fn len(self) -> usize;
 
     /// Determine if the Trie contains 0 key-value pairs.
+    #[inline]
     fn is_empty(self) -> bool {
         self.len() == 0
     }
 
     /// Determine if the trie is a leaf node (has no children).
+    #[inline]
     fn is_leaf(self) -> bool {
         self.trie_node().child_count == 0
     }
 
     /// Return an iterator over the keys and values of the Trie.
+    #[inline]
     fn iter(self) -> Iter<'a, K, V> {
         Iter::new(self.trie_node())
     }
 
     /// Return an iterator over the keys of the Trie.
+    #[inline]
     fn keys(self) -> Keys<'a, K, V> {
         Keys::new(self.iter())
     }
 
     /// Return an iterator over the values of the Trie.
+    #[inline]
     fn values(self) -> Values<'a, K, V> {
         Values::new(self.iter())
     }
@@ -50,7 +59,8 @@ where
     fn children(self) -> Children<'a, K, V>;
 
     /// Get the prefix of this node.
-    fn prefix(self) -> &'a NibbleVec {
+    #[inline]
+    fn prefix(self) -> &'a Nibblet {
         &self.trie_node().key
     }
 }
@@ -68,6 +78,7 @@ impl<'a, K: 'a, V: 'a> ContainsTrieNode<'a, K, V> for &'a Trie<K, V>
 where
     K: TrieKey,
 {
+    #[inline]
     fn trie_node(self) -> &'a TrieNode<K, V> {
         &self.node
     }
@@ -77,10 +88,11 @@ impl<'a, K: 'a, V: 'a> TrieCommon<'a, K, V> for &'a Trie<K, V>
 where
     K: TrieKey,
 {
+    #[inline]
     fn len(self) -> usize {
         self.length
     }
-
+    #[inline]
     fn children(self) -> Children<'a, K, V> {
         Children::new(self.node.key.clone(), &self.node)
     }
@@ -91,6 +103,7 @@ impl<'a: 'b, 'b, K: 'a, V: 'a> ContainsTrieNode<'a, K, V> for &'b SubTrie<'a, K,
 where
     K: TrieKey,
 {
+    #[inline]
     fn trie_node(self) -> &'a TrieNode<K, V> {
         self.node
     }
@@ -100,10 +113,11 @@ impl<'a: 'b, 'b, K: 'a, V: 'a> TrieCommon<'a, K, V> for &'b SubTrie<'a, K, V>
 where
     K: TrieKey,
 {
+    #[inline]
     fn len(self) -> usize {
         self.node.compute_size()
     }
-
+    #[inline]
     fn children(self) -> Children<'a, K, V> {
         Children::new(self.prefix.clone(), self.node)
     }
@@ -114,6 +128,7 @@ impl<'a, K: 'a, V: 'a> ContainsTrieNode<'a, K, V> for SubTrieMut<'a, K, V>
 where
     K: TrieKey,
 {
+    #[inline]
     fn trie_node(self) -> &'a TrieNode<K, V> {
         self.node
     }
@@ -124,10 +139,11 @@ where
     K: TrieKey,
 {
     /// **Computes** from scratch.
+    #[inline]
     fn len(self) -> usize {
         self.node.compute_size()
     }
-
+    #[inline]
     fn children(self) -> Children<'a, K, V> {
         Children::new(self.prefix.clone(), self.node)
     }
@@ -138,6 +154,7 @@ impl<'a: 'b, 'b, K: 'a, V: 'a> ContainsTrieNode<'b, K, V> for &'b SubTrieMut<'a,
 where
     K: TrieKey,
 {
+    #[inline]
     fn trie_node(self) -> &'b TrieNode<K, V> {
         self.node
     }
@@ -147,10 +164,11 @@ impl<'a: 'b, 'b, K: 'a, V: 'a> TrieCommon<'b, K, V> for &'b SubTrieMut<'a, K, V>
 where
     K: TrieKey,
 {
+    #[inline]
     fn len(self) -> usize {
         self.node.compute_size()
     }
-
+    #[inline]
     fn children(self) -> Children<'b, K, V> {
         Children::new(self.prefix.clone(), self.node)
     }


### PR DESCRIPTION
I figured since #60 I should do it sooner rather than later :laughing: 

```
trie insert             time:   [39.219 us 39.236 us 39.252 us]                         
                        change: [-1.0557% -0.9056% -0.7338%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

trie get                time:   [15.833 us 15.943 us 16.080 us]                      
                        change: [-34.247% -33.877% -33.457%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

trie remove             time:   [62.527 us 62.598 us 62.676 us]                        
                        change: [-12.890% -12.711% -12.549%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

```