### PR TITLE
Replace Travis CI with Github Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,17 @@
+name: Test suite
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo test --release --all-features
+      - run: cargo doc --no-deps --all-features
+      - run: cargo fmt -- --check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: rust
-os:
-  - linux
-before_script:
-  - rustup component add rustfmt-preview
-script:
-  - cargo test --verbose --features serde
-  - cargo doc --no-deps --features serde
-  - cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,5 @@ harness = false
 bench = false
 
 [badges]
-travis-ci = { repository = "michaelsproul/rust_radix_trie" }
 appveyor = { repository = "michaelsproul/rust_radix_trie" }
 maintenance = { status = "as-is" }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 Rust Radix Trie
 ====
 
-[![Unix Build Status](https://travis-ci.org/michaelsproul/rust_radix_trie.svg?branch=master)](https://travis-ci.org/michaelsproul/rust_radix_trie)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/d2voj1te0m7agfne/branch/master?svg=true)](https://ci.appveyor.com/project/michaelsproul/rust-radix-trie/branch/master)
 
 This is a [Radix Trie][radix-wiki] implementation in Rust, building on the lessons learnt from `TrieMap` and [Sequence Trie][seq-trie]. You can read about my experience implementing this data structure [here][radix-paper].


### PR DESCRIPTION
travis-ci.org has ceased to function and travis-ci.com acted up so it's going in the bin