### PR TITLE
perf: minor optimizations

### DIFF
--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -110,12 +110,17 @@ where
     /// Compute the number of keys and values in this node's subtrie.
     #[inline]
     pub fn compute_size(&self) -> usize {
-        let mut size = self.key_value.is_some() as usize;
+        let mut size = 0;
+        let mut stack = Vec::new();
+        stack.push(self);
 
-        for child in &self.children {
-            if let Some(ref child) = *child {
-                // TODO: could unroll this recursion
-                size += child.compute_size();
+        while !stack.is_empty() {
+            let top = stack.pop().unwrap();
+            size += top.key_value.is_some() as usize;
+            for child in &top.children {
+                if let Some(ref child) = child {
+                    stack.push(child);
+                }
             }
         }
 

--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -183,10 +183,9 @@ where
     /// Replace a value, returning the previous value if there was one.
     #[inline]
     pub fn replace_value(&mut self, key: K, value: V) -> Option<V> {
-        // TODO: optimise this?
-        let previous = self.take_value(&key);
-        self.add_key_value(key, value);
-        previous
+        let previous =
+            std::mem::replace(&mut self.key_value, Some(Box::new(KeyValue { key, value })));
+        previous.map(|kv| kv.value)
     }
 
     /// Get a reference to this node if it has a value.


### PR DESCRIPTION
This PR proposes a few optimizations based on comments in the code. 

1. Replace recursive `compute_size` with an iterative DFS.
2. Modify `replace_value` to not check if the new_key is equal to the old_key at the node, as it is called only if either `nv.len() == 0` or match_keys returns a `KeyMatch::Full` which implies that the compared keys match exactly. 
3. Replace `rec_remove` with an iterative version.

