### PR TITLE
Add `get_ancestor_mut()` API

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -162,16 +162,19 @@ fn nearest_ancestor_root() {
     let mut trie = Trie::new();
     trie.insert("", 55);
     assert_eq!(trie.get_ancestor_value(&""), Some(&55));
+    assert_eq!(trie.get_ancestor_value_mut(&""), Some(&mut 55));
 }
 
 #[test]
 fn nearest_ancestor() {
-    let trie = test_trie();
+    let mut trie = test_trie();
     assert_eq!(trie.get_ancestor_value(&""), None);
+    assert_eq!(trie.get_ancestor_value_mut(&""), None);
 
     // Test identity prefixes.
-    for &(key, val) in &TEST_DATA {
+    for &(key, mut val) in &TEST_DATA {
         assert_eq!(trie.get_ancestor_value(&key), Some(&val));
+        assert_eq!(trie.get_ancestor_value_mut(&key), Some(&mut val));
     }
 
     assert_eq!(trie.get_ancestor_value(&"abcdefg"), trie.get(&"abcdef"));
@@ -268,6 +271,7 @@ fn get_ancestor_bug() {
     trie.insert("abc", 1);
     trie.insert("abcde", 2);
     assert_eq!(trie.get_ancestor_value(&"abcdz"), Some(&1));
+    assert_eq!(trie.get_ancestor_value_mut(&"abcdz"), Some(&mut 1));
 }
 
 #[test]

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -38,6 +38,10 @@ where
         get_ancestor(self, nv)
     }
     #[inline]
+    pub fn get_ancestor_mut(&mut self, nv: &Nibblet) -> Option<(&mut TrieNode<K, V>, usize)> {
+        get_ancestor_mut(self, nv, 0, true)
+    }
+    #[inline]
     pub fn get_raw_ancestor(&self, nv: &Nibblet) -> (&TrieNode<K, V>, usize) {
         get_raw_ancestor(self, nv)
     }
@@ -307,6 +311,90 @@ where
             return ancestor.map(|anc| (anc, depth));
         }
     }
+}
+#[inline]
+fn get_ancestor_mut<'a, K, V>(
+    trie: &'a mut TrieNode<K, V>,
+    nv: &Nibblet,
+    mut depth: usize,
+    include_current: bool,
+) -> Option<(&'a mut TrieNode<K, V>, usize)>
+where
+    K: TrieKey,
+{
+    if nv.len() <= depth {
+        if include_current {
+            return trie.as_value_node_mut().map(|node| (node, 0))
+        } else {
+            return None
+        }
+    }
+
+    let mut prev = trie;
+    // The ancestor is such that all nodes up to and including `prev` have
+    // already been considered.
+
+    // First, we need to find a valid ancestor.
+    if !include_current || prev.as_value_node().is_none() {
+        loop {
+            let bucket = nv.get(depth) as usize;
+            let current = prev;
+            if let Some(child) = current.children[bucket].as_mut() {
+                match match_keys(depth, nv, &child.key) {
+                    KeyMatch::Full => return child.as_value_node_mut().map(|node| {
+                        let node_key_len = node.key.len();
+                        (node, depth + node_key_len)
+                    }),
+                    KeyMatch::FirstPrefix | KeyMatch::Partial(_) => {
+                        return None
+                    }
+                    KeyMatch::SecondPrefix => {
+                        depth += child.key.len();
+                        let is_ancestor = child.as_value_node().is_some();
+                        prev = child;
+                        if is_ancestor {
+                            break
+                        }
+                    }
+                }
+            } else {
+                return None
+            }
+        }
+    }
+
+    let mut ancestor = prev;
+
+    // First ancestor identified (though not necessarily the last)
+    // Now recursively find the final ancestor
+    loop {
+        // I don't like that we traverse twice here, but it seems the only way to satisfy the borrow
+        // checker. Otherwise, we're holding a &mut of ancestor for the lifetime of 'a while also
+        // asking for an Option value with that lifetime. Even though the mutable references are
+        // strictly used in different control flows, Rust's current borrow checker can't deduce that
+        // and so throws an error. We use a common workaround below where we first check for existence
+        // and then fetch it so that control flows are cleanly separated for the borrow checker.
+        if get_ancestor_mut(ancestor, nv, depth, false).is_none() {
+            return Some((ancestor, depth))
+        } else {
+            let (new_ancestor, new_depth) = get_ancestor_mut(ancestor, nv, depth, false).unwrap();
+            ancestor = new_ancestor;
+            depth = new_depth;
+        }
+    }
+
+    // This would be much cleaner, but cannot be done until the Polonius borrow checker is stable
+    /*
+    loop {
+        match get_ancestor_mut(ancestor, nv, depth, false) {
+            Some((new_ancestor, new_depth)) => {
+                ancestor = new_ancestor;
+                depth = new_depth;
+            }
+            None => return Some((ancestor, depth)),
+        }
+    }
+    */
 }
 #[inline]
 fn get_raw_ancestor<'a, K, V>(trie: &'a TrieNode<K, V>, nv: &Nibblet) -> (&'a TrieNode<K, V>, usize)

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -141,6 +141,32 @@ where
             })
     }
 
+    /// Fetch a mutable reference to the closest ancestor node of the given key.
+    ///
+    /// If `key` is encoded as byte-vector `b`, return the node `n` in the tree
+    /// such that `n`'s key's byte-vector is the longest possible prefix of `b`, and `n`
+    /// has a value.
+    ///
+    /// Invariant: `result.is_some() => result.key_value.is_some()`.
+    ///
+    /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
+    /// form *must* match those for the key type.
+    #[inline]
+    pub fn get_ancestor_mut<'a, Q: ?Sized>(&'a mut self, key: &Q) -> Option<SubTrieMut<'a, K, V>>
+    where
+        K: Borrow<Q>,
+        Q: TrieKey,
+    {
+        let mut key_fragments = key.encode();
+        let length_ref = &mut self.length;
+        self.node
+            .get_ancestor_mut(&key_fragments)
+            .map(|(node, node_key_len)| {
+                key_fragments.split(node_key_len);
+                node.as_subtrie_mut(key_fragments, length_ref)
+            })
+    }
+
     /// Fetch the closest ancestor *value* for a given key.
     ///
     /// See `get_ancestor` for precise semantics, this is just a shortcut.
@@ -154,6 +180,21 @@ where
         Q: TrieKey,
     {
         self.get_ancestor(key).and_then(|t| t.node.value())
+    }
+
+    /// Mutably fetch the closest ancestor *value* for a given key.
+    ///
+    /// See `get_ancestor_mut` for precise semantics, this is just a shortcut.
+    ///
+    /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed
+    /// form *must* match those for the key type.
+    #[inline]
+    pub fn get_ancestor_value_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: TrieKey,
+    {
+        self.get_ancestor_mut(key).and_then(|t| t.node.value_mut())
     }
 
     /// The key may be any borrowed form of the trie's key type, but TrieKey on the borrowed

--- a/src/trie_node.rs
+++ b/src/trie_node.rs
@@ -186,6 +186,16 @@ where
         self.key_value.as_ref().map(|_| self)
     }
 
+    /// Get a mutable reference to this node if it has a value.
+    #[inline]
+    pub fn as_value_node_mut(&mut self) -> Option<&mut TrieNode<K, V>> {
+        if self.key_value.is_some() {
+            Some(self)
+        } else {
+            None
+        }
+    }
+
     /// Split a node at a given index in its key, transforming it into a prefix node of its
     /// previous self.
     #[inline]


### PR DESCRIPTION
The current implementation only permits immutable borrows of ancestors. This PR adds a public function, `get_ancestor_mut()`, that returns a mutable borrow of a the nearest ancestor if any such ancestor exists.